### PR TITLE
Fix places where a nil object might be accessed

### DIFF
--- a/ie-user.go
+++ b/ie-user.go
@@ -102,10 +102,10 @@ func addUser(username, password string) {
 
 func loadUsersFromFile(filepath string) {
 	file, err := os.Open(filepath)
-	defer file.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {


### PR DESCRIPTION
While `defer file.Close()` is generally _good_, it's important to call it only after you've verified that `file` was successfully opened in the first place.  Otherwise, you're trying to call a function on a nil object.
